### PR TITLE
DM-6148: Deploy to LSST the Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: true
+language: python
+matrix:
+  include:
+    - python: "3.5"
+      env: LTD_MASON_BUILD=true
+before_install:
+  - "sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latexmk poppler-utils"
+install:
+  - pip install "ltd-mason>=0.2,<0.3"
+script:
+  - latexmk -bibtex -pdf -f DM_Applications_Design.tex
+  - pdfunite LDM-151-CoverPage.pdf DM_Applications_Design.pdf LDM-151.pdf
+  - latexmk -bibtex -pdf -f -cd blended-measurement/blended-measurement.tex
+after_success:
+  - cp LDM-151.pdf deployment/LDM-151.pdf
+  - cp blended-measurement/blended-measurement.pdf deployment/blended-measurement.pdf
+  - ltd-mason-travis --html-dir deployment
+env:
+  global:
+    - LTD_MASON_BUILD=false  # disable builds in regular text matrix
+    - LTD_MASON_PRODUCT="ldm-151"
+    # travis encrypt "LTD_MASON_AWS_ID=... LTD_MASON_AWS_SECRET=..." --add env.global 
+    - secure: "RIpSD83vWi85ef7vUVqkpYpd7RKQWm8rp4OqapnsIKhAU8e25lqwgC5lPCfXVnoqU9XSwdQxQvoHcSDuLhEnHVv5HnqqKEzRmNzdha+CHfhWDT48IEpguyLAREK2jVl4EfcbX5GQql6YCWyECw+W2PkkB3ThhylzRBbYQNzRlpurOD2G1rMrHgZHxBDX/+0ZOw4JClXu9MgR9hQuH3atRDGTXWpyNoAHVEZkVOukPdpX/L5GiKed6ghyYp+vCbcm/s0PMTKU8DqJOAkP5KEUyK0o3mgLzWfZ0eTG3FCAjU2RrcY7R/25bHIWg0hipsMKlJfAar/EWGLCRm6YkQLU90m2tAJBmHkPEYXmvPALxExemmRTOhmpWClsPGTPMFLEGPzO5ApexYyktxgjzyhqn3E++Koegr8eTVWAsN2yhus/bLOjDdgFk+oALTXZ2OOmWynkBjXesNFRiR2nG27x+W/wnPTvPTQYRrl6Dwv2VxTk9QT9JAhD/hz7vRBJJPwo2klbhmzFtO3v4GZOoo38qKyL0HN8ZwjDNCY5nBGHynCQHYnSiaC7uDnnGIe8DqlYst9Nb+bnFlfB4IyrrzejQUG6tdgJONyJxCA8k3wHQ493G4GPJzKZWn+/Bv6X5myvNiPTXgO3FTiQoLuuv57K0PV1/a/GbBajvgD3lD4ZRNo="
+    # travis encrypt "LTD_KEEPER_URL=... LTD_KEEPER_USER=... LTD_KEEPER_PASSWORD=..." --add env.global
+    - secure: "ABdjO8Yfz31zhMKmFUTebXOp+dtq/GIM3D4S/+Nr6lUxKg0WbBBUYARK7BYZ3ngOgmigD/8tSdQda5hk8ls7N+iHnik/GhTruZlqgJTWkhJ7girfEN+1rvfL/Khn8kc0TtSHLcpNU7GcGBO/VQY7g91iR9FR9IclM40Or76qJyvYkzt1s4aZxj4n+krWfI79hvc1Bs6vblnKbjOt7cL0XgcVIz7Api3zY8xCjIYkFLvqV4mT7rdvdqcVx0B+2mhhvP51rsVWhH4hXgFAfWsIQZ9kQ7UytOMTVgLQJAOb79sUWrKaXTPQ/M3K99Vxx4KlcRmxw5bWtQJ3GG7R8GvhN2ATgl4sTcGmhZ5r21RaPvVrIxorqZcTgWzrDf4JKuQxmLEEDGvj/PYqSKDzLIiDR3gQzxlJLh8HO6O0PcZVBVzgsW+A1nTEmiuz/4eN3+dppuJP4Sx8G/rqQ2Ja3oMSYt+FibJTkfNZLCzMkRa3VVsoaLFl28EvrLFjpXGkGx4azZYD+8owWeSm/86Xmed3j15NxM2ytMvTJ7WR1lruAoBh8JnltwKfWYKwvPoHnOCwOVoyQVW/oHc9Ee4xK0MlPdfh/dmngc0zP//90TRTNmB6Ss+izTfFcL8bBW9Im5kn2WHUrp0tqk14tVFZzcaac+HB+6c/6VBvG32YGVaE5g8="

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LDM-151: DM Applications Design
+
+The LSST Science Requirements Document (the [LSST SRD](https://docushare.lsstcorp.org/docushare/dsweb/Get/LPM-17)) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program. Following these guidelines, the details of these data products have been described in the LSST Data Products Definition Document ([DPDD](https://docushare.lsstcorp.org/docushare/dsweb/Get/LSE-163)), and captured in a formal flow-down from the SRD via the LSST System Requirements ([LSR](https://docushare.lsstcorp.org/docushare/dsweb/Get/LSE-29)), Observatory System Specifications ([OSS](https://docushare.lsstcorp.org/docushare/dsweb/Get/LSE-30)), to the Data Management System Requirements ([DMSR](https://docushare.lsstcorp.org/docushare/dsweb/Get/LSE-61)). LSST Data Management subsystem has the responsibility for design, implementation, deployment and execution of software pipelines necessary to generate these data products. This document, in conjunction with the UML Use Case model ([LDM-134](https://docushare.lsstcorp.org/docushare/dsweb/Get/LDM-134)), describes the design of the scientific aspects of those pipelines.
+
+## Continous Integration
+
+LDM-151 is continuously integrated wth [Travis CI](https://travis-ci.org/lsst/LDM-151) and published to [https://ldm-151.lsst.io](https://ldm-151.lsst.io).
+
+Each branch is published:
+
+- `master`: [https://ldm-151.lsst.io](https://ldm-151.lsst.io)
+- Ticket Branch `tickets/DM-XYWZ`: `https://ldm-151.lsst.io/v/DM-XYWZ/`
+- Other branches or tags: `https://ldm-151.lsst.io/v/(slug)/` where `(slug)` is the branch/tag name with `/` converted to `-`.

--- a/deployment/index.html
+++ b/deployment/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>LDM-151: DM Applications Design</title>
+    <meta name="description" content="Design of the scientific aspects of LSST Data Management pipelines.">
+    <link rel="canonical" href="https://ldm-151.lsst.io">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      html {
+        font-family: Helvetica;
+        color: #2c3e50;
+      }
+    </style
+  </head>
+
+  <body>
+    <h1>LDM-151: DM Applications Design</h1>
+    <p>This web page is automatically generated from <a href="https://github.com/lsst/ldm-151">lsst/LDM-151</a> on GitHub.</p>
+    <h2>PDF Downloads</h2>
+    <ul>
+      <li><a href="LDM-151.pdf">LDM-151</a></li>
+      <li><a href="blended-measurement.pdf">blended-measurement.pdf</a></li>
+    </ul>
+  </body>
+
+</html>
+


### PR DESCRIPTION
`.travis.yml` builds the two latex documents (using `latexmk` for robustness) and copies the artifacts to a `deployment/` directory. `deployment/` includes a simple HTML landing page.

[With ltd-mason-travis](), the PDFs and index.html landing page are deployed to LSST the Docs ([ldm-151.lsst.io](https://ldm-151.lsst.io))

README includes details of branch builds.
