### PR TITLE
Correctly exclude notes

### DIFF
--- a/LDM-151.tex
+++ b/LDM-151.tex
@@ -48,7 +48,7 @@
 
 \setDocRef{LDM-151}
 \setDocCurator{J.D.~Swinbank}
-\date{2017-05-19}
+\date{2017-07-19}
 
 \setDocAbstract{%
 The LSST Science Requirements Document (the LSST \SRD) specifies a set of data product guidelines, designed to support science goals envisioned to be enabled by the LSST observing program.

--- a/LDM-151.tex
+++ b/LDM-151.tex
@@ -70,6 +70,7 @@ The LSST Data Management subsystem's responsibilities include the design, implem
 \addtohist{3}{2013-10-07}{Updates for consistency with FDR baseline}{Mario Juric}
 \addtohist{}{2017-05-08}{Major reorganization for DM replan}{Mario Juric}
 \addtohist{4.0}{2017-05-19}{Approved in \href{https://jira.lsstcorp.org/browse/RFC-338}{RFC-338} and released.}{Mario Juric (approval), Tim Jenness (release)}
+\addtohist{4.1}{2017-07-19}{Remove development commentary. This content was included erroneously and was not part of the approved baseline.}{Tim Jenness}
 }
 
 

--- a/LDM-151.tex
+++ b/LDM-151.tex
@@ -29,6 +29,8 @@
 	\renewenvironment{note}[1][Note]
 	{}
 	{}
+
+  \excludecomment{note}
 \fi
 %%%%%%%%%%%%%%%%%%%%%
 

--- a/sections/alert_production_pipelines.tex
+++ b/sections/alert_production_pipelines.tex
@@ -368,7 +368,9 @@ Forced photometry is not required prior to alert generation. Completion of the p
 \end{center}
 \end{figure}
 
-\begin{note}{For ZI: I moved the precovery to a single pipeline}\end{note}
+\begin{note}
+  For ZI: I moved the precovery to a single pipeline
+\end{note}
 \subsubsection{Input Data}
 
 \paragraph*{Difference images:} A cache of DiffExps within a finite time interval (default 30 days) of the previous nights observations (inclusive of the previous nights data)


### PR DESCRIPTION
Blanking a note environment does not exclude the content from the document. This fixes that.